### PR TITLE
feat: Prototype of `Stack` widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /.vscode
+/.idea

--- a/crates/frui_core/src/api/contexts/render_ctx.rs
+++ b/crates/frui_core/src/api/contexts/render_ctx.rs
@@ -1,3 +1,4 @@
+use std::ops::{Sub, SubAssign};
 use std::{
     cell::{Ref, RefMut},
     marker::PhantomData,
@@ -50,6 +51,10 @@ impl Size {
     pub fn new(width: f64, height: f64) -> Self {
         Self { width, height }
     }
+
+    pub fn aspect_ratio(&self) -> f64 {
+        self.width / self.height
+    }
 }
 
 impl From<druid_shell::kurbo::Size> for Size {
@@ -74,6 +79,24 @@ impl AddAssign for Size {
     fn add_assign(&mut self, rhs: Self) {
         self.width += rhs.width;
         self.height += rhs.height;
+    }
+}
+
+impl SubAssign for Size {
+    fn sub_assign(&mut self, rhs: Self) {
+        self.width -= rhs.width;
+        self.height -= rhs.height;
+    }
+}
+
+impl Sub for Size {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self {
+            width: self.width - rhs.width,
+            height: self.height - rhs.height,
+        }
     }
 }
 
@@ -105,7 +128,7 @@ impl PartialOrd for Size {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Constraints {
     pub min_width: f64,
     pub max_width: f64,
@@ -130,12 +153,144 @@ impl Constraints {
         }
     }
 
-    pub fn tighten(&self) -> Self {
+    pub fn tighten(&self, width: Option<f64>, height: Option<f64>) -> Self {
         Self {
-            min_width: self.max_width,
-            max_width: self.max_width,
-            min_height: self.max_height,
-            max_height: self.max_height,
+            min_width: width.map_or(self.min_width, |w| w.clamp(self.min_width, self.max_width)),
+            max_width: width.map_or(self.max_width, |w| w.clamp(self.min_width, self.max_width)),
+            min_height: height.map_or(self.min_height, |h| {
+                h.clamp(self.min_height, self.max_height)
+            }),
+            max_height: height.map_or(self.max_height, |h| {
+                h.clamp(self.min_height, self.max_height)
+            }),
+        }
+    }
+
+    pub fn tight(size: Size) -> Self {
+        Self {
+            min_width: size.width,
+            max_width: size.width,
+            min_height: size.height,
+            max_height: size.height,
+        }
+    }
+
+    pub fn loose(size: Size) -> Self {
+        Self {
+            min_width: 0.0,
+            max_width: size.width,
+            min_height: 0.0,
+            max_height: size.height,
+        }
+    }
+
+    pub fn constrain_width(&self, width: Option<f64>) -> f64 {
+        width
+            .unwrap_or(f64::INFINITY)
+            .clamp(self.min_width, self.max_width)
+    }
+
+    pub fn constrain_height(&self, height: Option<f64>) -> f64 {
+        height
+            .unwrap_or(f64::INFINITY)
+            .clamp(self.min_height, self.max_height)
+    }
+
+    pub fn constrain(&self, size: Size) -> Size {
+        Size::new(
+            self.constrain_width(Some(size.width)),
+            self.constrain_height(Some(size.height)),
+        )
+    }
+
+    pub fn constrain_dimensions(&self, width: f64, height: f64) -> Size {
+        Size::new(
+            self.constrain_width(Some(width)),
+            self.constrain_height(Some(height)),
+        )
+    }
+
+    pub fn biggest(&self) -> Size {
+        Size::new(self.constrain_width(None), self.constrain_height(None))
+    }
+
+    pub fn smallest(&self) -> Size {
+        self.constrain_dimensions(0.0, 0.0)
+    }
+
+    pub fn has_tight_width(&self) -> bool {
+        self.min_width >= self.max_width
+    }
+
+    pub fn has_tight_height(&self) -> bool {
+        self.min_height >= self.max_height
+    }
+
+    pub fn is_tight(&self) -> bool {
+        self.has_tight_width() && self.has_tight_height()
+    }
+
+    pub fn constrains_size_with_aspect_ratio(&self, size: Size) -> Size {
+        if self.is_tight() {
+            self.smallest()
+        } else {
+            let aspect_ratio = size.aspect_ratio();
+            let mut width = size.width;
+            let mut height = size.height;
+
+            if width > self.max_width {
+                width = self.max_width;
+                height = width / aspect_ratio;
+            }
+
+            if height > self.max_height {
+                height = self.max_height;
+                width = height * aspect_ratio;
+            }
+
+            if width < self.min_width {
+                width = self.min_width;
+                height = width / aspect_ratio;
+            }
+
+            if height < self.min_height {
+                height = self.min_height;
+                width = height * aspect_ratio;
+            }
+
+            self.constrain_dimensions(width, height)
+        }
+    }
+
+    pub fn has_bounded_width(&self) -> bool {
+        self.max_width < f64::INFINITY
+    }
+
+    pub fn has_bounded_height(&self) -> bool {
+        self.max_height < f64::INFINITY
+    }
+
+    pub fn has_infinite_width(&self) -> bool {
+        self.min_width >= f64::INFINITY
+    }
+
+    pub fn has_infinite_height(&self) -> bool {
+        self.min_height >= f64::INFINITY
+    }
+
+    pub fn is_satisfied_by(&self, size: Size) -> bool {
+        (self.min_width..=self.max_width).contains(&size.width)
+            && (self.min_height..=self.max_height).contains(&size.height)
+    }
+}
+
+impl Default for Constraints {
+    fn default() -> Self {
+        Self {
+            min_width: 0.0,
+            max_width: f64::INFINITY,
+            min_height: 0.0,
+            max_height: f64::INFINITY,
         }
     }
 }
@@ -224,7 +379,7 @@ impl<'a, T> _RenderContext<'a, T> {
         self.ctx.child()
     }
 
-    pub fn children(&mut self) -> ChildIter
+    pub fn children(&mut self) -> ChildContextIter
     where
         T: MultiChildWidget,
     {
@@ -267,7 +422,7 @@ impl<'a> ChildContext<'a> {
         self.ctx.node.borrow().render_data.size
     }
 
-    pub fn try_data<'b, T: 'static>(&'b self) -> Option<Ref<'b, T>> {
+    pub fn try_data<T: 'static>(&self) -> Option<Ref<T>> {
         self.ctx
             .node
             .borrow()
@@ -277,6 +432,19 @@ impl<'a> ChildContext<'a> {
 
         Some(Ref::map(self.ctx.node.borrow(), |node| {
             node.render_data.state.downcast_ref().unwrap()
+        }))
+    }
+
+    pub fn try_data_mut<T: 'static>(&mut self) -> Option<RefMut<T>> {
+        self.ctx
+            .node
+            .borrow_mut()
+            .render_data
+            .state
+            .downcast_mut::<T>()?;
+
+        Some(RefMut::map(self.ctx.node.borrow_mut(), |node| {
+            node.render_data.state.downcast_mut().unwrap()
         }))
     }
 
@@ -317,8 +485,8 @@ impl AnyRenderContext {
         }
     }
 
-    pub(crate) fn children(&mut self) -> ChildIter {
-        ChildIter {
+    pub(crate) fn children(&mut self) -> ChildContextIter {
+        ChildContextIter {
             child_idx: 0,
             parent: &self.node,
         }
@@ -362,18 +530,18 @@ impl AnyRenderContext {
     }
 }
 
-pub struct ChildIter<'a> {
+pub struct ChildContextIter<'a> {
     child_idx: usize,
     parent: &'a WidgetNodeRef,
 }
 
-impl<'a> ChildIter<'a> {
+impl<'a> ChildContextIter<'a> {
     pub fn len(&self) -> usize {
         self.parent.children().len()
     }
 }
 
-impl<'a> Iterator for ChildIter<'a> {
+impl<'a> Iterator for ChildContextIter<'a> {
     type Item = ChildContext<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/crates/frui_widgets/src/flex/alignment.rs
+++ b/crates/frui_widgets/src/flex/alignment.rs
@@ -1,0 +1,278 @@
+use frui::prelude::{Offset, Size};
+use std::fmt::{Display, Formatter};
+use std::ops::{Add, Div, Mul, Neg, Sub};
+
+pub trait AlignmentGeometry {
+    fn x(&self) -> f64;
+
+    fn start(&self) -> f64;
+
+    fn y(&self) -> f64;
+
+    fn along(&self, other: Size) -> Offset;
+}
+
+#[derive(PartialEq, Copy, Clone, Debug, Default)]
+pub struct Alignment {
+    x: f64,
+    y: f64,
+}
+
+impl AlignmentGeometry for Alignment {
+    fn x(&self) -> f64 {
+        self.x
+    }
+
+    fn start(&self) -> f64 {
+        0.0
+    }
+
+    fn y(&self) -> f64 {
+        self.y
+    }
+
+    fn along(&self, other: Size) -> Offset {
+        let center_x = other.width / 2.0;
+        let center_y = other.height / 2.0;
+        Offset {
+            x: center_x + self.x * center_x,
+            y: center_y + self.y * center_y,
+        }
+    }
+}
+
+impl Alignment {
+    pub const TOP_LEFT: Alignment = Alignment { x: -1.0, y: -1.0 };
+    pub const TOP_CENTER: Alignment = Alignment { x: 0.0, y: -1.0 };
+    pub const TOP_RIGHT: Alignment = Alignment { x: 1.0, y: -1.0 };
+    pub const CENTER_LEFT: Alignment = Alignment { x: -1.0, y: 0.0 };
+    pub const CENTER: Alignment = Alignment { x: 0.0, y: 0.0 };
+    pub const CENTER_RIGHT: Alignment = Alignment { x: 1.0, y: 0.0 };
+    pub const BOTTOM_LEFT: Alignment = Alignment { x: -1.0, y: 1.0 };
+    pub const BOTTOM_CENTER: Alignment = Alignment { x: 0.0, y: 1.0 };
+    pub const BOTTOM_RIGHT: Alignment = Alignment { x: 1.0, y: 1.0 };
+
+    const PRELUDES: [(Alignment, &'static str); 9] = [
+        (Alignment::TOP_LEFT, "Alignment::TOP_LEFT"),
+        (Alignment::TOP_CENTER, "Alignment::TOP_CENTER"),
+        (Alignment::TOP_RIGHT, "Alignment::TOP_RIGHT"),
+        (Alignment::CENTER_LEFT, "Alignment::CENTER_LEFT"),
+        (Alignment::CENTER, "Alignment::CENTER"),
+        (Alignment::CENTER_RIGHT, "Alignment::CENTER_RIGHT"),
+        (Alignment::BOTTOM_LEFT, "Alignment::BOTTOM_LEFT"),
+        (Alignment::BOTTOM_CENTER, "Alignment::BOTTOM_CENTER"),
+        (Alignment::BOTTOM_RIGHT, "Alignment::BOTTOM_RIGHT"),
+    ];
+}
+
+impl Add for Alignment {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Alignment {
+            x: self.x + rhs.x,
+            y: self.y + rhs.y,
+        }
+    }
+}
+
+impl Sub for Alignment {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Alignment {
+            x: self.x - rhs.x,
+            y: self.y - rhs.y,
+        }
+    }
+}
+
+impl Neg for Alignment {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Alignment {
+            x: -self.x,
+            y: -self.y,
+        }
+    }
+}
+
+impl Display for Alignment {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        for (alignment, name) in Alignment::PRELUDES {
+            if alignment == *self {
+                return write!(f, "{}", name);
+            }
+        }
+        write!(f, "Alignment({}, {})", &self.x, &self.y)
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct AlignmentDirectional {
+    start: f64,
+    y: f64,
+}
+
+impl AlignmentGeometry for AlignmentDirectional {
+    fn x(&self) -> f64 {
+        0.0
+    }
+
+    fn start(&self) -> f64 {
+        self.start
+    }
+
+    fn y(&self) -> f64 {
+        self.y
+    }
+
+    fn along(&self, other: Size) -> Offset {
+        let center_x = other.width / 2.0;
+        let center_y = other.height / 2.0;
+        Offset {
+            x: center_x + self.x() * center_x,
+            y: center_y + self.y * center_y,
+        }
+    }
+}
+
+impl AlignmentDirectional {
+    fn new(start: f64, y: f64) -> Self {
+        Self { start, y }
+    }
+
+    pub const TOP_START: AlignmentDirectional = AlignmentDirectional {
+        start: -1f64,
+        y: -1f64,
+    };
+    pub const TOP_CENTER: AlignmentDirectional = AlignmentDirectional {
+        start: 0f64,
+        y: -1f64,
+    };
+    pub const TOP_END: AlignmentDirectional = AlignmentDirectional {
+        start: 1f64,
+        y: -1f64,
+    };
+    pub const CENTER_START: AlignmentDirectional = AlignmentDirectional {
+        start: -1f64,
+        y: 0f64,
+    };
+    pub const CENTER: AlignmentDirectional = AlignmentDirectional {
+        start: 0f64,
+        y: 0f64,
+    };
+    pub const CENTER_END: AlignmentDirectional = AlignmentDirectional {
+        start: 1f64,
+        y: 0f64,
+    };
+    pub const BOTTOM_START: AlignmentDirectional = AlignmentDirectional {
+        start: -1f64,
+        y: 1f64,
+    };
+    pub const BOTTOM_CENTER: AlignmentDirectional = AlignmentDirectional {
+        start: 0f64,
+        y: 1f64,
+    };
+    pub const BOTTOM_END: AlignmentDirectional = AlignmentDirectional {
+        start: 1f64,
+        y: 1f64,
+    };
+
+    const PRELUDES: [(AlignmentDirectional, &'static str); 9] = [
+        (
+            AlignmentDirectional::TOP_START,
+            "AlignmentDirectional::TOP_START",
+        ),
+        (
+            AlignmentDirectional::TOP_CENTER,
+            "AlignmentDirectional::TOP_CENTER",
+        ),
+        (
+            AlignmentDirectional::TOP_END,
+            "AlignmentDirectional::TOP_END",
+        ),
+        (
+            AlignmentDirectional::CENTER_START,
+            "AlignmentDirectional::CENTER_START",
+        ),
+        (AlignmentDirectional::CENTER, "AlignmentDirectional::CENTER"),
+        (
+            AlignmentDirectional::CENTER_END,
+            "AlignmentDirectional::CENTER_END",
+        ),
+        (
+            AlignmentDirectional::BOTTOM_START,
+            "AlignmentDirectional::BOTTOM_START",
+        ),
+        (
+            AlignmentDirectional::BOTTOM_CENTER,
+            "AlignmentDirectional::BOTTOM_CENTER",
+        ),
+        (
+            AlignmentDirectional::BOTTOM_END,
+            "AlignmentDirectional::BOTTOM_END",
+        ),
+    ];
+}
+
+impl Add for AlignmentDirectional {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        AlignmentDirectional {
+            start: self.start + rhs.start,
+            y: self.y + rhs.y,
+        }
+    }
+}
+
+impl Sub for AlignmentDirectional {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        AlignmentDirectional {
+            start: self.start - rhs.start,
+            y: self.y - rhs.y,
+        }
+    }
+}
+
+impl Neg for AlignmentDirectional {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        AlignmentDirectional {
+            start: -self.start,
+            y: -self.y,
+        }
+    }
+}
+
+impl Mul<f64> for AlignmentDirectional {
+    type Output = Self;
+
+    fn mul(self, rhs: f64) -> Self::Output {
+        AlignmentDirectional::new(self.start * rhs, self.y * rhs)
+    }
+}
+
+impl Div<f64> for AlignmentDirectional {
+    type Output = Self;
+
+    fn div(self, rhs: f64) -> Self::Output {
+        AlignmentDirectional::new(self.start / rhs, self.y / rhs)
+    }
+}
+
+impl Display for AlignmentDirectional {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        for (alignment, name) in AlignmentDirectional::PRELUDES {
+            if alignment == *self {
+                return write!(f, "{}", name);
+            }
+        }
+        write!(f, "AlignmentDirectional({}, {})", &self.start, &self.y)
+    }
+}

--- a/crates/frui_widgets/src/flex/mod.rs
+++ b/crates/frui_widgets/src/flex/mod.rs
@@ -7,6 +7,30 @@ pub use row::*;
 pub mod center;
 pub mod column;
 pub mod row;
+pub mod stack;
+pub mod alignment;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BoxLayoutData {
+    offset: Offset
+}
+
+pub trait LayoutData<T = BoxLayoutData> {
+    fn layout_data(&self) -> &T;
+
+    fn layout_data_mut(&mut self) -> &mut T;
+}
+
+impl LayoutData for BoxLayoutData {
+    fn layout_data(&self) -> &BoxLayoutData {
+        self
+    }
+
+    fn layout_data_mut(&mut self) -> &mut BoxLayoutData {
+        self
+    }
+}
+
 
 #[derive(Debug, Clone, Copy)]
 pub enum MainAxisSize {

--- a/crates/frui_widgets/src/flex/stack.rs
+++ b/crates/frui_widgets/src/flex/stack.rs
@@ -1,0 +1,260 @@
+use crate::alignment::{self, Alignment, AlignmentDirectional, AlignmentGeometry};
+use crate::{BoxLayoutData, LayoutData, WidgetList};
+use frui::prelude::*;
+use std::cell::Ref;
+
+pub enum StackFit {
+    Loose,
+    Expand,
+    Passthrough,
+}
+
+#[derive(MultiChildWidget)]
+pub struct Stack<T: WidgetList> {
+    pub children: T,
+    pub fit: StackFit,
+    pub alignment: &'static dyn AlignmentGeometry,
+}
+
+/// RenderData which Stack's children should hold, if not the child widget
+/// will be located at top-left with it's own size.
+#[derive(Copy, Clone, Default, Debug)]
+pub struct StackLayoutData {
+    pub base: BoxLayoutData,
+    pub top: Option<f64>,
+    pub right: Option<f64>,
+    pub bottom: Option<f64>,
+    pub left: Option<f64>,
+
+    /// The child's width.
+    ///
+    /// Ignored if both left and right are `Some(f64)`
+    pub width: Option<f64>,
+
+    /// The child's height.
+    ///
+    /// Ignored if both top and bottom are 'Some(f64)`
+    pub height: Option<f64>,
+}
+
+impl StackLayoutData {
+    fn is_positioned(&self) -> bool {
+        self.top.is_some()
+            || self.right.is_some()
+            || self.bottom.is_some()
+            || self.left.is_some()
+            || self.width.is_some()
+            || self.height.is_some()
+    }
+}
+
+impl LayoutData for StackLayoutData {
+    fn layout_data(&self) -> &BoxLayoutData {
+        &self.base
+    }
+
+    fn layout_data_mut(&mut self) -> &mut BoxLayoutData {
+        &mut self.base
+    }
+}
+
+impl Stack<()> {
+    pub fn builder() -> Self {
+        Stack {
+            children: (),
+            fit: StackFit::Loose,
+            alignment: &AlignmentDirectional::TOP_START,
+        }
+    }
+
+    fn layout_positioned_child(
+        child: &mut ChildContext,
+        size: Size,
+        alignment: &dyn AlignmentGeometry,
+    ) -> bool {
+        let mut has_visual_overflow = false;
+        let mut child_constraints = Constraints::default();
+        {
+            let child_layout_data = child.try_data::<StackLayoutData>().unwrap();
+            if child_layout_data.left.is_some() && child_layout_data.right.is_some() {
+                child_constraints = child_constraints.tighten(
+                    Some(
+                        size.width
+                            - child_layout_data.left.unwrap()
+                            - child_layout_data.right.unwrap(),
+                    ),
+                    None,
+                );
+            } else if child_layout_data.width.is_some() {
+                child_constraints = child_constraints.tighten(child_layout_data.width, None);
+            }
+
+            if child_layout_data.top.is_some() && child_layout_data.bottom.is_some() {
+                child_constraints = child_constraints.tighten(
+                    None,
+                    Some(
+                        size.height
+                            - child_layout_data.bottom.unwrap()
+                            - child_layout_data.top.unwrap(),
+                    ),
+                );
+            } else if child_layout_data.height.is_some() {
+                child_constraints = child_constraints.tighten(None, child_layout_data.height);
+            }
+        }
+        child.layout(child_constraints);
+        let child_size = child.size();
+        {
+            let mut child_layout_data = child.try_data_mut::<StackLayoutData>().unwrap();
+            let x = child_layout_data.left.unwrap_or_else(|| {
+                child_layout_data.right.map_or_else(
+                    || alignment.along(size - child_size).x,
+                    |right| size.width - right - child_size.width,
+                )
+            });
+
+            let y = child_layout_data.top.unwrap_or_else(|| {
+                child_layout_data.bottom.map_or_else(
+                    || alignment.along(size - child_size).y,
+                    |bottom| size.height - bottom - child_size.height,
+                )
+            });
+
+            has_visual_overflow |= x < 0.0
+                || x + child_size.width > size.width
+                || y < 0.0
+                || y + child_size.height > size.height;
+
+            child_layout_data.base.offset = Offset { x, y };
+        }
+        has_visual_overflow
+    }
+
+    fn is_positioned(child: &ChildContext) -> bool {
+        child
+            .try_data::<StackLayoutData>()
+            .map_or(false, |d| d.is_positioned())
+    }
+}
+
+impl<WidgetList_: WidgetList> Stack<WidgetList_> {
+    pub fn children(self, children: impl WidgetList) -> Stack<impl WidgetList> {
+        Stack {
+            children,
+            fit: self.fit,
+            alignment: self.alignment,
+        }
+    }
+
+    pub fn fit(mut self, fit: StackFit) -> Self {
+        self.fit = fit;
+        self
+    }
+
+    pub fn alignment(mut self, alignment: &'static dyn AlignmentGeometry) -> Self {
+        self.alignment = alignment;
+        self
+    }
+
+    fn get_layout_offset(&self, child: &ChildContext, size: Size) -> Offset {
+        let child_size = child.size();
+        child.try_data::<StackLayoutData>().map_or_else(
+            || self.alignment.along(size - child_size),
+            |data| data.base.offset,
+        )
+    }
+}
+
+impl<T: WidgetList> MultiChildWidget for Stack<T> {
+    fn build<'w>(&'w self, ctx: BuildContext<'w, Self>) -> Vec<Self::Widget<'w>> {
+        self.children.get()
+    }
+
+    fn layout(&self, ctx: RenderContext<Self>, constraints: Constraints) -> Size {
+        let mut width = constraints.min_width;
+        let mut height = constraints.min_height;
+        let non_positioned_constraints = match self.fit {
+            StackFit::Loose => constraints.loosen(),
+            StackFit::Expand => Constraints::tight(constraints.biggest()),
+            StackFit::Passthrough => constraints,
+        };
+        let mut has_non_positioned_child = false;
+        for mut child in ctx.children() {
+            if !Stack::is_positioned(&child) {
+                has_non_positioned_child = true;
+                let child_size = child.layout(non_positioned_constraints);
+                width = width.max(child_size.width);
+                height = height.max(child_size.height);
+            }
+        }
+
+        let size = if has_non_positioned_child {
+            Size::new(width, height)
+        } else {
+            constraints.biggest()
+        };
+
+        for mut child in ctx.children() {
+            let child_size = child.size();
+            if !Stack::is_positioned(&child) {
+                if let Some(mut layout_data) = child.try_data_mut::<StackLayoutData>() {
+                    layout_data.base.offset = self.alignment.along(size - child_size);
+                }
+            } else {
+                Stack::layout_positioned_child(&mut child, size, self.alignment);
+            }
+        }
+        size
+    }
+
+    fn paint(&self, ctx: RenderContext<Self>, canvas: &mut PaintContext, offset: &Offset) {
+        let size = ctx.size();
+        for mut child in ctx.children() {
+            child.paint(canvas, &self.get_layout_offset(&child, size));
+        }
+    }
+}
+
+#[derive(SingleChildWidget, Default)]
+pub struct Positioned<T: Widget> {
+    pub child: T,
+    pub left: Option<f64>,
+    pub right: Option<f64>,
+    pub top: Option<f64>,
+    pub bottom: Option<f64>,
+    pub width: Option<f64>,
+    pub height: Option<f64>,
+}
+
+impl<T: Widget> RenderState for Positioned<T> {
+    type State = StackLayoutData;
+
+    fn create_state(&self) -> Self::State {
+        StackLayoutData {
+            base: BoxLayoutData::default(),
+            top: self.top,
+            right: self.right,
+            bottom: self.bottom,
+            left: self.left,
+            width: self.width,
+            height: self.height,
+        }
+    }
+}
+
+impl<T> SingleChildWidget for Positioned<T>
+where
+    T: Widget,
+{
+    fn build<'w>(&'w self, ctx: BuildContext<'w, Self>) -> Self::Widget<'w> {
+        &self.child
+    }
+
+    fn layout(&self, ctx: RenderContext<Self>, constraints: Constraints) -> Size {
+        ctx.child().layout(constraints)
+    }
+
+    fn paint(&self, ctx: RenderContext<Self>, canvas: &mut PaintContext, offset: &Offset) {
+        ctx.child().paint(canvas, offset)
+    }
+}

--- a/examples/stack.rs
+++ b/examples/stack.rs
@@ -13,15 +13,15 @@ struct App;
 
 impl ViewWidget for App {
     fn build<'w>(&'w self, _: BuildContext<'w, Self>) -> Self::Widget<'w> {
-        Stack::builder()
-            .alignment(&Alignment::TOP_CENTER)
+        Stack::builder() //
+            .alignment(Alignment::TOP_CENTER)
             .children((
                 Text::new("🦀").size(100.0).weight(FontWeight::BOLD),
                 Positioned {
                     child: Container::builder()
-                    .color(Color::GREEN)
-                    .width(50.0)
-                    .height(50.0),
+                        .color(Color::GREEN)
+                        .width(50.0)
+                        .height(50.0),
                     right: Some(10.0),
                     bottom: Some(10.0),
                     left: None,

--- a/examples/stack.rs
+++ b/examples/stack.rs
@@ -1,0 +1,53 @@
+#![feature(type_alias_impl_trait)]
+
+use frui::prelude::*;
+
+mod misc;
+use frui_widgets::{
+    alignment::Alignment,
+    stack::{Positioned, Stack},
+};
+
+#[derive(ViewWidget)]
+struct App;
+
+impl ViewWidget for App {
+    fn build<'w>(&'w self, _: BuildContext<'w, Self>) -> Self::Widget<'w> {
+        Stack::builder()
+            .alignment(&Alignment::TOP_CENTER)
+            .children((
+                Text::new("🦀").size(100.0).weight(FontWeight::BOLD),
+                Positioned {
+                    child: Container::builder()
+                    .color(Color::GREEN)
+                    .width(50.0)
+                    .height(50.0),
+                    right: Some(10.0),
+                    bottom: Some(10.0),
+                    left: None,
+                    top: None,
+                    width: None,
+                    height: None,
+                },
+                Positioned {
+                    child: Container::builder()
+                        .color(Color::GREEN)
+                        .width(50.0)
+                        .height(50.0),
+                    right: Some(10.0),
+                    bottom: Some(10.0),
+                    left: Some(10.0),
+                    top: Some(50.0),
+                    width: None,
+                    height: None,
+                },
+                Center {
+                    child: Text::new("🦀").size(100.0).weight(FontWeight::BOLD),
+                },
+            ))
+    }
+}
+
+fn main() {
+    run_app(App);
+}


### PR DESCRIPTION
## Run example

```shell
cargo run --example stack
```

## How to use

```rust
Stack::builder()
            .alignment(&Alignment::TOP_CENTER)
            .children((
                Text::new("🦀").size(100.0).weight(FontWeight::BOLD),
                Positioned {
                    child: Container::builder()
                    .color(Color::GREEN)
                    .width(50.0)
                    .height(50.0),
                    right: Some(10.0),
                    bottom: Some(10.0),
                    left: None,
                    top: None,
                    width: None,
                    height: None,
                },
                Positioned {
                    child: Container::builder()
                        .color(Color::GREEN)
                        .width(50.0)
                        .height(50.0),
                    right: Some(10.0),
                    bottom: Some(10.0),
                    left: Some(10.0),
                    top: Some(50.0),
                    width: None,
                    height: None,
                },
                Center {
                    child: Text::new("🦀").size(100.0).weight(FontWeight::BOLD),
                },
            ))
```
### Preview
<img width="500" alt="image" src="https://user-images.githubusercontent.com/2241197/197570905-754b74e8-af36-4651-a1df-6201fd086d65.png">
