### PR TITLE
feat: impl request_close for WindowHandler

### DIFF
--- a/crates/frui_core/src/app/runner/handler.rs
+++ b/crates/frui_core/src/app/runner/handler.rs
@@ -191,4 +191,8 @@ impl FruiWindowHandler for WindowHandler {
 
         true
     }
+
+    fn request_close(&mut self) {
+        self.window_handle.close();
+    }
 }

--- a/crates/frui_core/src/app/runner/mod.rs
+++ b/crates/frui_core/src/app/runner/mod.rs
@@ -54,4 +54,6 @@ pub trait FruiWindowHandler {
     fn wheel(&mut self, event: &MouseEvent);
 
     fn key_down(&mut self, event: KeyEvent) -> bool;
+
+    fn request_close(&mut self);
 }

--- a/crates/frui_core/src/app/runner/native/mod.rs
+++ b/crates/frui_core/src/app/runner/native/mod.rs
@@ -110,4 +110,8 @@ impl WinHandler for WindowHandler {
     fn key_down(&mut self, event: KeyEvent) -> bool {
         FruiWindowHandler::key_down(self, event)
     }
+
+    fn request_close(&mut self) {
+        FruiWindowHandler::request_close(self)
+    }
 }


### PR DESCRIPTION
Users can now close the window by clicking the close button.

# Preview
![request_close](https://user-images.githubusercontent.com/16167062/197818874-835bcd2a-e663-40e6-9b26-42ba98a1a332.gif)
