### PR TITLE
opt: `Alignment` implementation

### DIFF
--- a/crates/frui_core/src/api/contexts/render_ctx.rs
+++ b/crates/frui_core/src/api/contexts/render_ctx.rs
@@ -47,6 +47,15 @@ pub struct Size {
     pub height: f64,
 }
 
+impl From<Offset> for Size {
+    fn from(value: Offset) -> Self {
+        Size {
+            width: value.x,
+            height: value.y,
+        }
+    }
+}
+
 impl Size {
     pub fn new(width: f64, height: f64) -> Self {
         Self { width, height }

--- a/crates/frui_widgets/src/flex/stack.rs
+++ b/crates/frui_widgets/src/flex/stack.rs
@@ -10,10 +10,10 @@ pub enum StackFit {
 }
 
 #[derive(MultiChildWidget)]
-pub struct Stack<WL: WidgetList> {
+pub struct Stack<WL: WidgetList, A: AlignmentGeometry> {
     pub children: WL,
     pub fit: StackFit,
-    pub alignment: AlignmentGeometry,
+    pub alignment: A,
     pub text_direction: TextDirection,
 }
 
@@ -59,7 +59,7 @@ impl LayoutData for StackLayoutData {
     }
 }
 
-impl Stack<()> {
+impl Stack<(), AlignmentDirectional> {
     pub fn builder() -> Self {
         Stack {
             children: (),
@@ -69,7 +69,7 @@ impl Stack<()> {
         }
     }
 
-    fn layout_positioned_child(child: &mut ChildContext, size: Size, alignment: Alignment) -> bool {
+    fn layout_positioned_child(child: &mut ChildContext, size: Size, alignment: &Alignment) -> bool {
         let mut has_visual_overflow = false;
         let mut child_constraints = Constraints::default();
         {
@@ -135,8 +135,8 @@ impl Stack<()> {
     }
 }
 
-impl<WL: WidgetList> Stack<WL> {
-    pub fn children(self, children: impl WidgetList) -> Stack<impl WidgetList> {
+impl<WL: WidgetList, A: AlignmentGeometry> Stack<WL, A> {
+    pub fn children(self, children: impl WidgetList) -> Stack<impl WidgetList, impl AlignmentGeometry> {
         Stack {
             children,
             fit: self.fit,
@@ -145,7 +145,7 @@ impl<WL: WidgetList> Stack<WL> {
         }
     }
 
-    pub fn alignment(self, alignment: AlignmentGeometry) -> Stack<WL> {
+    pub fn alignment(self, alignment: A) -> Stack<WL, A> {
         Stack {
             children: self.children,
             fit: self.fit,
@@ -168,7 +168,7 @@ impl<WL: WidgetList> Stack<WL> {
     }
 }
 
-impl<WL: WidgetList> MultiChildWidget for Stack<WL> {
+impl<WL: WidgetList, A: AlignmentGeometry> MultiChildWidget for Stack<WL, A> {
     fn build<'w>(&'w self, _: BuildContext<'w, Self>) -> Vec<Self::Widget<'w>> {
         self.children.get()
     }
@@ -205,7 +205,7 @@ impl<WL: WidgetList> MultiChildWidget for Stack<WL> {
                     layout_data.base.offset = alignment.along(size - child_size);
                 }
             } else {
-                Stack::layout_positioned_child(&mut child, size, alignment);
+                Stack::layout_positioned_child(&mut child, size, &alignment);
             }
         }
         size

--- a/crates/frui_widgets/src/flex/stack.rs
+++ b/crates/frui_widgets/src/flex/stack.rs
@@ -159,6 +159,11 @@ impl<WL: WidgetList, A: AlignmentGeometry> Stack<WL, A> {
         self
     }
 
+    pub fn text_direction(mut self, text_direction: TextDirection) -> Self {
+        self.text_direction = text_direction;
+        self
+    }
+
     fn get_layout_offset(&self, child: &ChildContext, alignment: &Alignment, size: Size) -> Offset {
         let child_size = child.size();
         child.try_data::<StackLayoutData>().map_or_else(

--- a/crates/frui_widgets/src/flex/stack.rs
+++ b/crates/frui_widgets/src/flex/stack.rs
@@ -136,7 +136,7 @@ impl Stack<(), AlignmentDirectional> {
 }
 
 impl<WL: WidgetList, A: AlignmentGeometry> Stack<WL, A> {
-    pub fn children(self, children: impl WidgetList) -> Stack<impl WidgetList, impl AlignmentGeometry> {
+    pub fn children(self, children: impl WidgetList) -> Stack<impl WidgetList, A> {
         Stack {
             children,
             fit: self.fit,
@@ -145,7 +145,7 @@ impl<WL: WidgetList, A: AlignmentGeometry> Stack<WL, A> {
         }
     }
 
-    pub fn alignment(self, alignment: A) -> Stack<WL, A> {
+    pub fn alignment(self, alignment: impl AlignmentGeometry) -> Stack<WL, impl AlignmentGeometry> {
         Stack {
             children: self.children,
             fit: self.fit,
@@ -215,8 +215,7 @@ impl<WL: WidgetList, A: AlignmentGeometry> MultiChildWidget for Stack<WL, A> {
         let alignment = self.alignment.resolve(&self.text_direction);
         let size = ctx.size();
         for mut child in ctx.children() {
-            let offset = self.get_layout_offset(&child, &alignment, size);
-            child.paint(canvas, &offset);
+            child.paint(canvas, &self.get_layout_offset(&child, &alignment, size));
         }
     }
 }

--- a/crates/frui_widgets/src/text.rs
+++ b/crates/frui_widgets/src/text.rs
@@ -5,6 +5,12 @@ use druid_shell::piet::{
     TextLayoutBuilder,
 };
 
+#[derive(Debug)]
+pub enum TextDirection {
+    Rtl,
+    Ltr,
+}
+
 #[derive(LeafWidget)]
 pub struct Text<S: AsRef<str>> {
     text: S,

--- a/examples/stack.rs
+++ b/examples/stack.rs
@@ -10,7 +10,7 @@ struct App;
 impl ViewWidget for App {
     fn build<'w>(&'w self, _: BuildContext<'w, Self>) -> Self::Widget<'w> {
         Stack::builder() //
-            .alignment(Alignment::TOP_CENTER)
+            .alignment(AlignmentDirectional::CENTER_END)
             .children((
                 Text::new("🦀").size(100.0).weight(FontWeight::BOLD),
                 Positioned {


### PR DESCRIPTION
~The polymorphism of abstract class `AlignmentGeometry` in Rust with`trait` is ugly, and it cannot apply to third-party crate `derive_builder`。
Now change it to two separated struct and wrap them with a sum type `AlignmentGeometry`, which can be hold in widget with the same type.~
Add `TextDirection` and resolve from `AlignmentGeometry` into `Alignment`